### PR TITLE
IMP --single-tag options: no delete of multi tags image

### DIFF
--- a/gricleaner.py
+++ b/gricleaner.py
@@ -337,14 +337,14 @@ if __name__ == "__main__":
 
                     created = dateutil.parser.parse(image["created"]).replace(tzinfo=None)
                     diff = today - created
-                    logging.debug("Tag {} with image id {} days diff: {}".format(tag, image["id"], diff.days))
+                    logging.debug("Tag {} with image id {} days diff: {}".format(tag, image.get('id', False), diff.days))
                     if diff.days > retention_days:
                         logging.warning("- DELETE: {}:{}, Created at {} ({} days ago)".
                                         format(repository,
                                                 tag,
                                                 created.replace(microsecond=0),
                                                 diff.days))
-                        GRICleaner.delete_image(repository, tag, image_id=image[id])
+                        GRICleaner.delete_image(repository, tag, image_id=image.get('id', False))
                         filtered_tags.remove(tag)
                         images_deleted += 1
 


### PR DESCRIPTION
Hi N0madic,

I know there is a similar PR (#10), here the approach i use to not delete images that have N tags, thanks for any suggestions, and perhaps some piece of code if this PR could help.
Currently tested and approved in dry-run.

- the behaviour is only activated with the --single-tag flag
- clean-all ignore --single-tag

use cases:

the main idea is to always curl all images when --single-tag is activated, because if you select images with a regexp, a selected image could have a co-tag that do not match the regexp, and image is accidently deleted!. a cache is used so that images loaded within this pass are not reloaded later.

using --single-tag you are able to not delete "master commit tags" that are tied to release tags like "prod", "staging", "dev", ...
