### PR TITLE
WIP: preserve tags new switch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ optional arguments:
   --clean-latest        also clean 'latest' tags (by default they're excluded from removal)
   --clean-all           delete all images in repository (DANGER!)
   --single-tag          only delete images with one tag (no 'co-tag' delete)
+  --preserve-tags       preserve images used by given tags (example --preserve-tags=master,prod,staging,latest)
   --dry-run             not delete actually
   -z, --insecure        disable SSL certificate verification
   -v, --verbose         verbose mode

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -214,6 +214,10 @@ if __name__ == "__main__":
         help="only delete images with one tag (no 'co-tag' delete)"
     )
     parser.add_argument(
+        "--preserve-tags",
+        help="preserve images used by given tags (example --preserve-tags=master,prod,staging,latest)"
+    )
+    parser.add_argument(
         "--dry-run", action="store_true", help="not delete actually")
     parser.add_argument(
         "-z", "--insecure", action="store_true", help="disable SSL certificate verification")
@@ -240,6 +244,10 @@ if __name__ == "__main__":
     elif args.ini:
         logging.critical("Config {} not found!".format(args.ini))
         sys.exit(1)
+
+    if args.single_tag and args.preserve_tags:
+        logging.error("--single-tag and --preserve-tags can not be used together")
+    preserve_tags = args.preserve_tags and list(map(lambda x: x.strip(), args.preserve_tags.split(','))) or []
 
     if args.insecure:
         requests.packages.urllib3.disable_warnings()

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -83,7 +83,7 @@ class GitlabRegistryClient(object):
             "Accept": "application/vnd.docker.distribution.manifest.v2+json"
         }
         response = requests.head(self.registry + path, headers=headers, verify=self.requests_verify)
-        if response.status_code == 404:
+        if response.status_code == 404 or not response.headers["Docker-Content-Digest"]:
             logging.info("- Not found")
             return None
 

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -84,7 +84,7 @@ class GitlabRegistryClient(object):
         }
         response = requests.head(self.registry + path, headers=headers, verify=self.requests_verify)
         if response.status_code == 404 or "Docker-Content-Digest" not in response.headers:
-            logging.info("- Not found")
+            logging.warning("Digest not found ! {} {}".format(response.status_code, json.dumps(response.headers)))
             return None
 
         return response.headers["Docker-Content-Digest"]

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -84,7 +84,7 @@ class GitlabRegistryClient(object):
         }
         response = requests.head(self.registry + path, headers=headers, verify=self.requests_verify)
         if response.status_code == 404 or "Docker-Content-Digest" not in response.headers:
-            logging.warning("Digest not found ! {} {}".format(response.status_code, json.dumps(response.headers)))
+            logging.warning("Digest not found ! {} {}".format(response.status_code, str(response.headers)))
             return None
 
         return response.headers["Docker-Content-Digest"]

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -83,7 +83,7 @@ class GitlabRegistryClient(object):
             "Accept": "application/vnd.docker.distribution.manifest.v2+json"
         }
         response = requests.head(self.registry + path, headers=headers, verify=self.requests_verify)
-        if response.status_code == 404 or not response.headers["Docker-Content-Digest"]:
+        if response.status_code == 404 or "Docker-Content-Digest" not in response.headers:
             logging.info("- Not found")
             return None
 

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -18,7 +18,7 @@ class GitlabRegistryClient(object):
         self.requests_verify = requests_verify
         self.dry_run = dry_run
 
-    @cachetools.func.ttl_cache(maxsize=100, ttl=10 * 60)
+    @cachetools.func.ttl_cache(maxsize=100, ttl=59) # gitlab jwt token expires each 60s: ttl 59
     def get_bearer(self, scope):
         """Return bearer token from Gitlab jwt"""
         url = "{}/?service=container_registry&scope={}:*".format(self.jwt, scope)

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -83,7 +83,7 @@ class GitlabRegistryClient(object):
             "Accept": "application/vnd.docker.distribution.manifest.v2+json"
         }
         response = requests.head(self.registry + path, headers=headers, verify=self.requests_verify)
-        if response.status_code == 404 or "Docker-Content-Digest" not in response.headers:
+        if response.status_code == 404 or response.status_code == 401 or "Docker-Content-Digest" not in response.headers:
             logging.warning("Digest not found ! {} {}".format(response.status_code, str(response.headers)))
             return None
 

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -332,7 +332,7 @@ if __name__ == "__main__":
             if use_image_cache:
                 # load all tags images in cache
                 # to identify later if each used by severals tags
-                logging.info("loading all images tags in cache...")
+                logging.warning("loading all images tags in cache...")
                 for tag in tags["tags"]:
                     GRICleaner.get_image(repository, tag)
 

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -91,18 +91,19 @@ class GitlabRegistryClient(object):
 
     def delete_image(self, repo, tag, image_id=False):
         """Delete image by tag from registry. returns False if deletion is skipped"""
-        if args.single_tag and image_id:
-            image_tags = image_tags_by_id.get(image_id, []).copy()
-            if image_tags:
-                image_tags.remove(tag)  # deduce tag itself
-                if image_tags:  # other co-tags
+        if use_image_cache and image_id:
+            cotags = image_tags_by_id.get(image_id, []).copy()
+            if cotags:
+                cotags.remove(tag)  # deduce tag itself
+                if args.single_tag and cotags:
+                    # single-tag flag and other co-tags: cancel delete
                     logging.warning(
                         "Delete cancelled !"
                         " Image {repo}:{tag} is not candidate for deletion\n"
                         " --single-tag and image used by other tags: {tags}".format(
                             repo=repo,
                             tag=tag,
-                            tags=",".join(image_tags)
+                            tags=",".join(cotags)
                         )
                     )
                     return False

--- a/gricleaner.py
+++ b/gricleaner.py
@@ -18,7 +18,7 @@ class GitlabRegistryClient(object):
         self.requests_verify = requests_verify
         self.dry_run = dry_run
 
-    @cachetools.func.ttl_cache(maxsize=100, ttl=59) # gitlab jwt token expires each 60s: ttl 59
+    @cachetools.func.ttl_cache(maxsize=100, ttl=59)  # gitlab jwt token expires each 60s: ttl 59
     def get_bearer(self, scope):
         """Return bearer token from Gitlab jwt"""
         url = "{}/?service=container_registry&scope={}:*".format(self.jwt, scope)


### PR DESCRIPTION
Hi nOmadic,

proposal of new option (we currently use in our CI). actually works well in our CI, indeed caring any of your input, perhaps you would pick some elements/ideas!

use case, in a repo you want to keep release tags (and related commit tags - same image) and delete other oldest images

--preserve-tags=master,prod,staging,latest -d 20

now then --preserve-tags or --singletag options (exclusives) are used, -n and - r are optional versus required (always required in other cases)